### PR TITLE
slurm_spank_init: return early if lua_script_list is empty

### DIFF
--- a/lua/lua.c
+++ b/lua/lua.c
@@ -1328,6 +1328,9 @@ int slurm_spank_init (spank_t sp, int ac, char *av[])
 {
     if (spank_lua_init (sp, ac, av) < 0)
         return (-1);
+
+    if (lua_script_list == NULL)
+        return (0);
     /*
      *  Register options in global 'spank_options' table
      */


### PR DESCRIPTION
In the Lua SPANK plugin, if no Lua script exist in the script list, the plugin will generate a segfault when trying to create the spank table:
```
(gdb) bt
#0  0x00007ffff6d99c30 in pthread_mutex_lock () from /usr/lib64/libpthread.so.0
#1  0x00007ffff7481d71 in list_iterator_create (l=0x0) at list.c:607
#2  0x00007ffff4e4075e in spank_lua_options_table_register () from /usr/lib64/slurm/lua.so
#3  0x00007ffff4e40e2b in slurm_spank_init () from /usr/lib64/slurm/lua.so
#4  0x00007ffff753c953 in _do_call_stack (stack=<optimized out>, type=type@entry=SPANK_INIT, job=job@entry=0x0, taskid=taskid@entry=-1) at plugstack.c:747
#5  0x00007ffff753ddfe in _spank_init (context=context@entry=S_TYPE_SLURMD, job=job@entry=0x0) at plugstack.c:780
#6  0x00007ffff753de32 in spank_slurmd_init () at plugstack.c:841
#7  0x000000000040e8e7 in _slurmd_init () at slurmd.c:1463
#8  main (argc=2, argv=0x7fffffffe418) at slurmd.c:258
```

A solution is to return early in `slurm_spank_init()` if the list is empty.